### PR TITLE
Replace mcrypt with sodium

### DIFF
--- a/classes/kohana/encrypt.php
+++ b/classes/kohana/encrypt.php
@@ -1,22 +1,8 @@
 <?php defined('SYSPATH') or die('No direct script access.');
 /**
  * The Encrypt library provides two-way encryption of text and binary strings
- * using the [Mcrypt](http://php.net/mcrypt) extension, which consists of three
- * parts: the key, the cipher, and the mode.
- *
- * The Key
- * :  A secret passphrase that is used for encoding and decoding
- *
- * The Cipher
- * :  A [cipher](http://php.net/mcrypt.ciphers) determines how the encryption
- *    is mathematically calculated. By default, the "rijndael-128" cipher
- *    is used. This is commonly known as "AES-128" and is an industry standard.
- *
- * The Mode
- * :  The [mode](http://php.net/mcrypt.constants) determines how the encrypted
- *    data is written in binary form. By default, the "nofb" mode is used,
- *    which produces short output with high entropy.
- *
+ * using the [Sodium](https://www.php.net/manual/en/book.sodium.php) extension.
+
  * @package    Kohana
  * @category   Security
  * @author     Kohana Team
@@ -24,190 +10,112 @@
  * @license    http://kohanaframework.org/license
  */
 class Kohana_Encrypt {
+	/**
+	 * @var string
+	 */
+	private static $default = 'default';
 
 	/**
-	 * @var  string  default instance name
+	 * @var array
 	 */
-	public static $default = 'default';
+	private static $instances = [];
 
 	/**
-	 * @var  array  Encrypt class instances
+	 * @var string
 	 */
-	public static $instances = array();
+	private $key;
 
 	/**
-	 * @var  string  OS-dependent RAND type to use
+	 * @param string $key Encryption key (hexadecimal)
 	 */
-	protected static $_rand;
+	public function __construct($key)
+	{
+		$this->key = hex2bin($key);
+	}
+
+	/**
+	 * Encrypts the data and returns it as a base 64 encoded string.
+	 *
+	 * @param string $data
+	 *
+	 * @return string
+	 */
+	public function encode($data)
+	{
+		$nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+		$encryptedData = sodium_crypto_secretbox($data, $nonce, $this->key);
+
+		// Base 64 encode the encrypted data.
+		return base64_encode(bin2hex($nonce.$encryptedData));
+	}
+
+	/**
+	 * Decrypts the encoded base 64 data to it's original value.
+	 * Returns false if the decryption fails.
+	 *
+	 * @param string $data
+	 *
+	 * @return string|false
+	 */
+	public function decode($data)
+	{
+		$data = base64_decode($data, true);
+
+		if (!$data)
+		{
+			return false;
+		}
+
+		// Nonce is twice the size when converted to hexadecimal.
+		$nonceSize = SODIUM_CRYPTO_SECRETBOX_NONCEBYTES * 2;
+
+		// Extract the nonce (hexadecimal) from the data (hexadecimal).
+		$nonce = substr($data, 0, $nonceSize);
+
+		// Remove the nonce from the data.
+		$data = substr($data, $nonceSize);
+
+		$encryptedData = sodium_crypto_secretbox_open(hex2bin($data), hex2bin($nonce), $this->key);
+
+		if (!$encryptedData)
+		{
+			return false;
+		}
+
+		return $encryptedData;
+	}
 
 	/**
 	 * Returns a singleton instance of Encrypt. An encryption key must be
 	 * provided in your "encrypt" configuration file.
 	 *
-	 *     $encrypt = Encrypt::instance();
+	 * @param string $name configuration group name
 	 *
-	 * @param   string  $name   configuration group name
-	 * @return  Encrypt
+	 * @return self
 	 */
-	public static function instance($name = NULL)
+	public static function instance($name = null)
 	{
-		if ($name === NULL)
+		if ($name === null)
 		{
-			// Use the default instance name
-			$name = Encrypt::$default;
+			$name = self::$default;
 		}
 
-		if ( ! isset(Encrypt::$instances[$name]))
+		if (!isset(self::$instances[$name]))
 		{
 			// Load the configuration data
-			$config = Kohana::$config->load('encrypt')->$name;
+			$config = \Kohana::$config->load('encrypt')->$name;
 
-			if ( ! isset($config['key']))
+			if (!isset($config['key']))
 			{
 				// No default encryption key is provided!
-				throw new Kohana_Exception('No encryption key is defined in the encryption configuration group: :group',
+				throw new \Kohana_Exception('No encryption key is defined in the encryption configuration group: :group',
 					array(':group' => $name));
 			}
 
-			if ( ! isset($config['mode']))
-			{
-				// Add the default mode
-				$config['mode'] = MCRYPT_MODE_NOFB;
-			}
-
-			if ( ! isset($config['cipher']))
-			{
-				// Add the default cipher
-				$config['cipher'] = MCRYPT_RIJNDAEL_128;
-			}
-
 			// Create a new instance
-			Encrypt::$instances[$name] = new Encrypt($config['key'], $config['mode'], $config['cipher']);
+			self::$instances[$name] = new self($config['key']);
 		}
 
-		return Encrypt::$instances[$name];
+		return self::$instances[$name];
 	}
-
-	/**
-	 * Creates a new mcrypt wrapper.
-	 *
-	 * @param   string  $key    encryption key
-	 * @param   string  $mode   mcrypt mode
-	 * @param   string  $cipher mcrypt cipher
-	 */
-	public function __construct($key, $mode, $cipher)
-	{
-		// Find the max length of the key, based on cipher and mode
-		$size = mcrypt_get_key_size($cipher, $mode);
-
-		if (isset($key[$size]))
-		{
-			// Shorten the key to the maximum size
-			$key = substr($key, 0, $size);
-		}
-
-		// Store the key, mode, and cipher
-		$this->_key    = $key;
-		$this->_mode   = $mode;
-		$this->_cipher = $cipher;
-
-		// Store the IV size
-		$this->_iv_size = mcrypt_get_iv_size($this->_cipher, $this->_mode);
-	}
-
-	/**
-	 * Encrypts a string and returns an encrypted string that can be decoded.
-	 *
-	 *     $data = $encrypt->encode($data);
-	 *
-	 * The encrypted binary data is encoded using [base64](http://php.net/base64_encode)
-	 * to convert it to a string. This string can be stored in a database,
-	 * displayed, and passed using most other means without corruption.
-	 *
-	 * @param   string  $data   data to be encrypted
-	 * @return  string
-	 */
-	public function encode($data)
-	{
-		// Set the rand type if it has not already been set
-		if (Encrypt::$_rand === NULL)
-		{
-			if (Kohana::$is_windows)
-			{
-				// Windows only supports the system random number generator
-				Encrypt::$_rand = MCRYPT_RAND;
-			}
-			else
-			{
-				if (defined('MCRYPT_DEV_URANDOM'))
-				{
-					// Use /dev/urandom
-					Encrypt::$_rand = MCRYPT_DEV_URANDOM;
-				}
-				elseif (defined('MCRYPT_DEV_RANDOM'))
-				{
-					// Use /dev/random
-					Encrypt::$_rand = MCRYPT_DEV_RANDOM;
-				}
-				else
-				{
-					// Use the system random number generator
-					Encrypt::$_rand = MCRYPT_RAND;
-				}
-			}
-		}
-
-		if (Encrypt::$_rand === MCRYPT_RAND)
-		{
-			// The system random number generator must always be seeded each
-			// time it is used, or it will not produce true random results
-			mt_srand();
-		}
-
-		// Create a random initialization vector of the proper size for the current cipher
-		$iv = mcrypt_create_iv($this->_iv_size, Encrypt::$_rand);
-
-		// Encrypt the data using the configured options and generated iv
-		$data = mcrypt_encrypt($this->_cipher, $this->_key, $data, $this->_mode, $iv);
-
-		// Use base64 encoding to convert to a string
-		return base64_encode($iv.$data);
-	}
-
-	/**
-	 * Decrypts an encoded string back to its original value.
-	 *
-	 *     $data = $encrypt->decode($data);
-	 *
-	 * @param   string  $data   encoded string to be decrypted
-	 * @return  FALSE   if decryption fails
-	 * @return  string
-	 */
-	public function decode($data)
-	{
-		// Convert the data back to binary
-		$data = base64_decode($data, TRUE);
-
-		if ( ! $data)
-		{
-			// Invalid base64 data
-			return FALSE;
-		}
-
-		// Extract the initialization vector from the data
-		$iv = substr($data, 0, $this->_iv_size);
-
-		if ($this->_iv_size !== strlen($iv))
-		{
-			// The iv is not the expected size
-			return FALSE;
-		}
-
-		// Remove the iv from the data
-		$data = substr($data, $this->_iv_size);
-
-		// Return the decrypted data, trimming the \0 padding bytes from the end of the data
-		return rtrim(mcrypt_decrypt($this->_cipher, $this->_key, $data, $this->_mode, $iv), "\0");
-	}
-
-} // End Encrypt
+}

--- a/classes/kohana/encrypt.php
+++ b/classes/kohana/encrypt.php
@@ -91,7 +91,7 @@ class Kohana_Encrypt {
 		$encryptedData = sodium_crypto_secretbox($data, $nonce, $this->key);
 
 		// Base 64 encode the encrypted data.
-		return base64_encode(bin2hex($nonce.$encryptedData));
+		return base64_encode($nonce.$encryptedData);
 	}
 
 	/**
@@ -112,15 +112,15 @@ class Kohana_Encrypt {
 		}
 
 		// Nonce is twice the size when converted to hexadecimal.
-		$nonceSize = SODIUM_CRYPTO_SECRETBOX_NONCEBYTES * 2;
+		$nonceSize = SODIUM_CRYPTO_SECRETBOX_NONCEBYTES;
 
-		// Extract the nonce (hexadecimal) from the data (hexadecimal).
+		// Extract the nonce from the data.
 		$nonce = substr($data, 0, $nonceSize);
 
 		// Remove the nonce from the data.
 		$data = substr($data, $nonceSize);
 
-		$encryptedData = sodium_crypto_secretbox_open(hex2bin($data), hex2bin($nonce), $this->key);
+		$encryptedData = sodium_crypto_secretbox_open($data, $nonce, $this->key);
 
 		if (!$encryptedData)
 		{

--- a/classes/kohana/encrypt.php
+++ b/classes/kohana/encrypt.php
@@ -62,7 +62,7 @@ class Kohana_Encrypt {
 	/**
 	 * @param string $key Encryption key (hexadecimal)
 	 */
-	public function __construct($key)
+	public function __construct(string $key)
 	{
 		$this->key = hex2bin($key);
 	}

--- a/classes/kohana/encrypt.php
+++ b/classes/kohana/encrypt.php
@@ -31,16 +31,16 @@ class Kohana_Encrypt {
 	 *
 	 * @param string $name configuration group name
 	 *
-	 * @return self
+	 * @return Encrypt
 	 */
 	public static function instance($name = null)
 	{
 		if ($name === null)
 		{
-			$name = self::$default;
+			$name = Encrypt::$default;
 		}
 
-		if (!isset(self::$instances[$name]))
+		if (!isset(Encrypt::$instances[$name]))
 		{
 			// Load the configuration data
 			$config = \Kohana::$config->load('encrypt')->$name;
@@ -48,15 +48,15 @@ class Kohana_Encrypt {
 			if (!isset($config['key']))
 			{
 				// No default encryption key is provided!
-				throw new \Kohana_Exception('No encryption key is defined in the encryption configuration group: :group',
+				throw new Kohana_Exception('No encryption key is defined in the encryption configuration group: :group',
 					array(':group' => $name));
 			}
 
 			// Create a new instance
-			self::$instances[$name] = new self($config['key']);
+			Encrypt::$instances[$name] = new Encrypt($config['key']);
 		}
 
-		return self::$instances[$name];
+		return Encrypt::$instances[$name];
 	}
 
 	/**
@@ -69,7 +69,7 @@ class Kohana_Encrypt {
 		if (strlen($key) !== SODIUM_CRYPTO_SECRETBOX_KEYBYTES)
 		{
 			// The key has the wrong length
-			throw new \Kohana_Exception(
+			throw new Kohana_Exception(
 				'The encryption key must have a length of :number bytes',
 				[':number' => SODIUM_CRYPTO_SECRETBOX_KEYBYTES]
 			);

--- a/classes/kohana/encrypt.php
+++ b/classes/kohana/encrypt.php
@@ -66,7 +66,7 @@ class Kohana_Encrypt {
 	{
 		$key = hex2bin($key);
 
-		if (mb_strlen($key, '8bit') !== SODIUM_CRYPTO_SECRETBOX_KEYBYTES)
+		if (strlen($key) !== SODIUM_CRYPTO_SECRETBOX_KEYBYTES)
 		{
 			// The key has the wrong length
 			throw new \Kohana_Exception(

--- a/classes/kohana/encrypt.php
+++ b/classes/kohana/encrypt.php
@@ -64,7 +64,18 @@ class Kohana_Encrypt {
 	 */
 	public function __construct(string $key)
 	{
-		$this->key = hex2bin($key);
+		$key = hex2bin($key);
+
+		if (mb_strlen($key, '8bit') !== SODIUM_CRYPTO_SECRETBOX_KEYBYTES)
+		{
+			// The key has the wrong length
+			throw new \Kohana_Exception(
+				'The encryption key must have a length of :number bytes',
+				[':number' => SODIUM_CRYPTO_SECRETBOX_KEYBYTES]
+			);
+		}
+
+		$this->key = $key;
 	}
 
 	/**

--- a/classes/kohana/encrypt.php
+++ b/classes/kohana/encrypt.php
@@ -13,17 +13,51 @@ class Kohana_Encrypt {
 	/**
 	 * @var string
 	 */
-	private static $default = 'default';
+	public static $default = 'default';
 
 	/**
 	 * @var array
 	 */
-	private static $instances = [];
+	public static $instances = [];
 
 	/**
 	 * @var string
 	 */
 	private $key;
+
+	/**
+	 * Returns a singleton instance of Encrypt. An encryption key must be
+	 * provided in your "encrypt" configuration file.
+	 *
+	 * @param string $name configuration group name
+	 *
+	 * @return self
+	 */
+	public static function instance($name = null)
+	{
+		if ($name === null)
+		{
+			$name = self::$default;
+		}
+
+		if (!isset(self::$instances[$name]))
+		{
+			// Load the configuration data
+			$config = \Kohana::$config->load('encrypt')->$name;
+
+			if (!isset($config['key']))
+			{
+				// No default encryption key is provided!
+				throw new \Kohana_Exception('No encryption key is defined in the encryption configuration group: :group',
+					array(':group' => $name));
+			}
+
+			// Create a new instance
+			self::$instances[$name] = new self($config['key']);
+		}
+
+		return self::$instances[$name];
+	}
 
 	/**
 	 * @param string $key Encryption key (hexadecimal)
@@ -85,37 +119,5 @@ class Kohana_Encrypt {
 		return $encryptedData;
 	}
 
-	/**
-	 * Returns a singleton instance of Encrypt. An encryption key must be
-	 * provided in your "encrypt" configuration file.
-	 *
-	 * @param string $name configuration group name
-	 *
-	 * @return self
-	 */
-	public static function instance($name = null)
-	{
-		if ($name === null)
-		{
-			$name = self::$default;
-		}
 
-		if (!isset(self::$instances[$name]))
-		{
-			// Load the configuration data
-			$config = \Kohana::$config->load('encrypt')->$name;
-
-			if (!isset($config['key']))
-			{
-				// No default encryption key is provided!
-				throw new \Kohana_Exception('No encryption key is defined in the encryption configuration group: :group',
-					array(':group' => $name));
-			}
-
-			// Create a new instance
-			self::$instances[$name] = new self($config['key']);
-		}
-
-		return self::$instances[$name];
-	}
-}
+} // End Encrypt

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Fork of Kohana Core",
 	"license": "BSD-3-Clause",
 	"require": {
-		"php": "~5.3"
+		"php": "^7.3"
 	},
 	"replace": {
 		"kohana/core": "3.2.*"

--- a/config/encrypt.php
+++ b/config/encrypt.php
@@ -4,14 +4,10 @@ return array(
 
 	'default' => array(
 		/**
-		 * The following options must be set:
+		 * The following option must be set:
 		 *
-		 * string   key     secret passphrase
-		 * integer  mode    encryption mode, one of MCRYPT_MODE_*
-		 * integer  cipher  encryption cipher, one of the Mcrpyt cipher constants
+		 * string key Sodium key
 		 */
-		'cipher' => MCRYPT_RIJNDAEL_128,
-		'mode'   => MCRYPT_MODE_NOFB,
 	),
 
 );


### PR DESCRIPTION
Refactor the Kohana Encrypt class to use `sodium` instead of `mcrypt`, which was removed in PHP 7.2